### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/aiw-devops/570ab01f-1c5c-41c1-88f0-9cba550e869d/f89d0c8d-08d7-4185-894e-b8fb031a5291/_apis/work/boardbadge/0dd61702-4406-40ba-9bb5-9cad3f940be4)](https://dev.azure.com/aiw-devops/570ab01f-1c5c-41c1-88f0-9cba550e869d/_boards/board/t/f89d0c8d-08d7-4185-894e-b8fb031a5291/Microsoft.RequirementCategory)
 # Contoso Traders
 
 ![Logo](./docs/images/logo-1280x640.png)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2980](https://dev.azure.com/aiw-devops/570ab01f-1c5c-41c1-88f0-9cba550e869d/_workitems/edit/2980). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.